### PR TITLE
Add potatOS

### DIFF
--- a/dns/domains.py
+++ b/dns/domains.py
@@ -26,5 +26,6 @@ domains: Dict[str, Domain] = {
 
     "metis": { "cname": "squiddev-cc.github.io" },
     "plethora": { "cname": "squiddev-cc.github.io" },
+    "potatos": { "cname": "osmarks.tk" }
     "www": { "cname": "madefor.cc" },
 }


### PR DESCRIPTION
This adds potatos.madefor.cc to the list of domains.