### PR TITLE
Add `skydocs` to the `madefor.cc` domain

### DIFF
--- a/dns/domains.py
+++ b/dns/domains.py
@@ -29,5 +29,6 @@ domains: Dict[str, Domain] = {
     "metis": { "cname": "squiddev-cc.github.io" },
     "plethora": { "cname": "squiddev-cc.github.io" },
     "potatos": { "cname": "osmarks.tk" },
+    "skydocs": { "cname": "skythecodemaster.github.io" },
     "www": { "cname": "madefor.cc" },
 }


### PR DESCRIPTION
This adds my website, `skythecodemaster.github.io` to the `madefor.cc` domain.