### PR TITLE
Add thox amongst the domains

### DIFF
--- a/dns/domains.py
+++ b/dns/domains.py
@@ -31,5 +31,6 @@ domains: Dict[str, Domain] = {
     "plethora": { "cname": "squiddev-cc.github.io" },
     "potatos": { "cname": "osmarks.tk" },
     "skydocs": { "cname": "skythecodemaster.github.io" },
+    "thox": { "cname": "thox.touhey.pro" },
     "www": { "cname": "madefor.cc" },
 }


### PR DESCRIPTION
thox is an OS project for ComputerCraft. For now it mainly consists of a documentation of external components and of the OS design, not a valid implementation yet; but as it documents many components from other OSes and projects, such as OPUS and OneOS, I consider it ready to be submitted for the madefor.cc domain; hence this pull request.

A subtility: ``thox.touhey.pro``, the project's current domain, is actually defined on the DNS level as a wildcard (``*.touhey.pro``), my project hosting domain / hosting. But the CNAME should work, and if this pull request is accepted, I'll add a redirection for thox for the madefor.cc domain to be the canonical one. :)

Thanks for your work on CC:T <3