### PR TITLE
add basalt at pyroxenium.github.io

### DIFF
--- a/dns/domains.py
+++ b/dns/domains.py
@@ -24,6 +24,7 @@ class Domain(DomainOptional):
 domains: Dict[str, Domain] = {
     # Please make sure to keep this sorted!
 
+    "basalt": { "cname": "pyroxenium.github.io" },
     "brag": { "cname": "bragosmagos.github.io" },
     "cash": { "cname": "mcjack123.github.io" },
     "craftos-pc": { "cname": "admiring-shannon-be238c.netlify.app" },


### PR DESCRIPTION
Hello! I am hoping to add the basalt project at https://github.com/Pyroxenium/Basalt, it has a documentation setup here: https://pyroxenium.github.io/Basalt/