### PR TITLE
Add ccsimplegui to the list of domains

### DIFF
--- a/dns/domains.py
+++ b/dns/domains.py
@@ -27,7 +27,7 @@ domains: Dict[str, Domain] = {
     "basalt": { "cname": "pyroxenium.github.io" },
     "brag": { "cname": "bragosmagos.github.io" },
     "cash": { "cname": "mcjack123.github.io" },
-    "ccsimplegui": { "cname": "masongulu.github.io/CCSimpleGUI/" },
+    "ccsimplegui": { "cname": "masongulu.github.io" },
     "consult" : {"cname": "1Turtle.github.io"},
     "craftos-pc": { "cname": "admiring-shannon-be238c.netlify.app" },
     "gemstone": { "cname": "gemstone.znepb.me" },

--- a/dns/domains.py
+++ b/dns/domains.py
@@ -27,6 +27,7 @@ domains: Dict[str, Domain] = {
     "basalt": { "cname": "pyroxenium.github.io" },
     "brag": { "cname": "bragosmagos.github.io" },
     "cash": { "cname": "mcjack123.github.io" },
+    "ccsimplegui": { "cname": "masongulu.github.io/CCSimpleGUI/" },
     "consult" : {"cname": "1Turtle.github.io"},
     "craftos-pc": { "cname": "admiring-shannon-be238c.netlify.app" },
     "gemstone": { "cname": "gemstone.znepb.me" },


### PR DESCRIPTION
I hope I have gotten this right, I noticed most others just have github.io as the page linked to.

CCSimpleGUI is a GUI library at https://github.com/MasonGulu/CCSimpleGUI