### PR TITLE
add mc-cc-scripts.github.io to domains

### DIFF
--- a/dns/domains.py
+++ b/dns/domains.py
@@ -34,6 +34,7 @@ domains: Dict[str, Domain] = {
     "plethora": { "cname": "squiddev-cc.github.io" },
     "potatos": { "cname": "osmarks.net" },
     "recrafted": { "cname": "ocawesome101.github.io" },
+    "scm": { "cname": "mc-cc-scripts.github.io" },
     "ships": {"cname":"ships.knijn.one"},
     "skydocs": { "cname": "skythecodemaster.github.io" },
     "skygui": { "cname": "skythecodemaster.github.io" },


### PR DESCRIPTION
Also fixes spacing for consistence.

---

SCM is a Script Manager to easily install programs from GitHub or Pastebin without having to care about libraries too much.