### PR TITLE
Added x.madefor.cc to dns/domains.py

### DIFF
--- a/dns/domains.py
+++ b/dns/domains.py
@@ -45,4 +45,5 @@ domains: Dict[str, Domain] = {
     "webify": { "cname": "webify.knijn.one" },
     "wolf-os": { "cname": "cc-wolf-os.github.io" },
     "www": { "cname": "madefor.cc" },
+    "x": { "cname": "lua-cratestry.deno.dev" },
 }


### PR DESCRIPTION
Lua-Cratestry is a module registry for lua modules. Modules are uploaded to an S3 bucket for immutability. Modules are published when a git tag is pushed (via webhook).