### PR TITLE
Add uwuntucc.madefor.cc domain

### DIFF
--- a/dns/domains.py
+++ b/dns/domains.py
@@ -42,6 +42,7 @@ domains: Dict[str, Domain] = {
     "skygui": { "cname": "skythecodemaster.github.io" },
     "thox": { "cname": "thox.touhey.pro" },
     "unicornpkg": { "cname": "unicornpkg.github.io" },
+    "uwuntucc": { "cname": "sall0-0p.github.io" },
     "webify": { "cname": "webify.knijn.one" },
     "wolf-os": { "cname": "cc-wolf-os.github.io" },
     "www": { "cname": "madefor.cc" },


### PR DESCRIPTION
UwUntuCC is quite new desktop enviroment (2 mounth of active development).

Github: https://github.com/sall0-0p/UwUntuCC/tree/dev

Actual screenshot.
![2022-11-28_20 32 08](https://user-images.githubusercontent.com/79805623/204359539-f8b041ab-154e-4aeb-ba99-f7758d9c8b7a.png)

I need this site, because Im trying to provide some services and custom functionality and I need to make docs for it =)
