### PR TITLE
Remove freax domain

### DIFF
--- a/dns/domains.py
+++ b/dns/domains.py
@@ -25,7 +25,6 @@ domains: Dict[str, Domain] = {
     "ccloner": { "cname": "hzfishy.github.io" },
     "consult" : {"cname": "1Turtle.github.io"},
     "craftos-pc": { "cname": "admiring-shannon-be238c.netlify.app" },
-    "freax": { "cname": "freax.netlify.app" },
     "guih": { "cname": "9551-dev.github.io" },
     "impulsive-cc": { "cname": "emeraldimpulse7.github.io" },
     "infernity": { "cname": "infernostars.github.io" },


### PR DESCRIPTION
I have archived the FREAX "operating system" and would like to remove the redundant subdomain.