### PR TITLE
Added cloveros to dns registry

### DIFF
--- a/dns/domains.py
+++ b/dns/domains.py
@@ -63,4 +63,5 @@ domains: Dict[str, Domain] = {
     "www": { "cname": "madefor.cc" },
     "xcc": { "cname": "shlomo1412.github.io" },
     "youcube": { "cname": "cc-youcube.github.io" },
+    "cloveros": { "cname": "palordersoftworksofficial.github.io" },
 }


### PR DESCRIPTION
My git pages is a CDN!
for example that they can do this:
wget run http://cloveros.madefor.cc/netinstall.lua or:
wget run https://cloveros.madefor.cc/netinstall.lua and yes you can directly browse the files