### PR TITLE
Added cloveros to dns registry

### DIFF
--- a/dns/domains.py
+++ b/dns/domains.py
@@ -26,6 +26,7 @@ domains: Dict[str, Domain] = {
     "charmap": {"cname": "shrekshellraiser.github.io"},
     "consult" : {"cname": "1Turtle.github.io"},
     "craftos-pc": { "cname": "admiring-shannon-be238c.netlify.app" },
+    "cloveros": { "cname": "palordersoftworksofficial.github.io" },
     "datapacks": { "cname": "cc-tweaked.github.io" },
     "epoch": { "cname": "haeleon.github.io" },
     "guih": { "cname": "9551-dev.github.io" },


### PR DESCRIPTION
My git pages is a CDN!
for example that they can do this:
wget run http://cloveros.madefor.cc/netinstall.lua or: wget run https://cloveros.madefor.cc/netinstall.lua and yes you can directly browse the files