### PR TITLE
Update domains.py to remove impulsive-cc.madefor.cc

### DIFF
--- a/dns/domains.py
+++ b/dns/domains.py
@@ -31,7 +31,6 @@ domains: Dict[str, Domain] = {
     "datapacks": { "cname": "cc-tweaked.github.io" },
     "epoch": { "cname": "haeleon.github.io" },
     "guih": { "cname": "9551-dev.github.io" },
-    "impulsive-cc": { "cname": "emeraldimpulse7.github.io" },
     "infernity": { "cname": "infernostars.github.io" },
     "kristify": { "cname": "kristify.github.io"},
     "metis": { "cname": "squiddev-cc.github.io" },


### PR DESCRIPTION
impulsive-cc.madefor.cc is unused, and is an artifact of an older online identity. I'd like to remove it. 

Also, when I originally added it, it was in the wrong order anyway.